### PR TITLE
feat: support mongodb array update operator $[]

### DIFF
--- a/package/lib/SimpleSchema.tests.js
+++ b/package/lib/SimpleSchema.tests.js
@@ -1330,4 +1330,34 @@ describe('SimpleSchema', function () {
       });
     });
   });
+  describe('support mongodb array update operator $[]', function () {
+    it('simple positional modify all operator $[]', function() {
+      const schema = new SimpleSchema({ someArray: Array, "someArray.$": String });
+      expectValid(
+        schema,
+        { $set: { 'someArray.$[]': "a" } },
+        { modifier: true },
+      );
+    });
+    it('simple positional modifier with arrayFilter identifier', function() {
+      const schema = new SimpleSchema({ someArray: Array, "someArray.$": String });
+      expectValid(
+        schema,
+        { $set: { 'someArray.$[identifier]': "a" } },
+        { modifier: true },
+      );
+    });
+    it('nested update with positional modifier with arrayFilter identifier', function() {
+      const schema = new SimpleSchema({ 
+        someArray: Array,
+        "someArray.$": Object,
+        "someArray.$.someValue": Number
+      });
+      expectValid(
+        schema,
+        { $inc: { 'someArray.$[identifier].someValue': 1 } },
+        { modifier: true },
+      );
+    });
+  })
 });

--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -5834,9 +5834,9 @@
       "dev": true
     },
     "mongo-object": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/mongo-object/-/mongo-object-0.1.4.tgz",
-      "integrity": "sha512-QtYk0gupWEn2+iB+DDRt1L+WbcNYvJRaHdih/dcqthOa1DbnREUGSs2WGcW478GNYpElflo/yybZXu0sTiRXHg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mongo-object/-/mongo-object-2.0.0.tgz",
+      "integrity": "sha512-E6MrS7CEgpoV+Y9l3WdFqI4lmX/MC6lK76jzXpAZIemb85elWtrgIZfi0wUDn40IlFMpPoUcsE86sHX1ErhnEw=="
     },
     "ms": {
       "version": "2.0.0",

--- a/package/package.json
+++ b/package/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "clone": "^2.1.2",
     "message-box": "^0.2.7",
-    "mongo-object": "^0.1.4"
+    "mongo-object": "^2.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.13.14",


### PR DESCRIPTION
fixes #378

This pr adds support for the mongodb array update operator $[] by updating mongo-object to the newest version. mongo-object received an update lately specifically to support this feature in the way described in https://github.com/longshotlabs/simpl-schema/issues/378#issuecomment-689840464.

This pr only adds tests to show that the update operator works with this version of mongo-object.

Please feel free to move, change and extend the tests and edit the commit message.
