### PR TITLE
Fix `keys` validation option not being respected

### DIFF
--- a/src/doValidation.ts
+++ b/src/doValidation.ts
@@ -111,7 +111,7 @@ function doValidation ({
   if (wholeDocumentErrors.length > 0) {
     validationErrors.push(...wholeDocumentErrors)
   }
-  
+
   function isIgnoredKey (key: string): boolean {
     if (!Array.isArray(keysToValidate)) return false
     for (const keyToValidate of keysToValidate) {

--- a/src/doValidation.ts
+++ b/src/doValidation.ts
@@ -115,7 +115,7 @@ function doValidation ({
   function isIgnoredKey (key: string): boolean {
     if (!Array.isArray(keysToValidate)) return false
     for (const keyToValidate of keysToValidate) {
-      if (keyToValidate === key || key.startsWith(`${key}.`)) return false
+      if (keyToValidate === key || key.startsWith(`${keyToValidate}.`)) return false
     }
     return true
   }

--- a/src/doValidation.ts
+++ b/src/doValidation.ts
@@ -118,6 +118,8 @@ function doValidation ({
     if (ignoreTypes?.includes(errObj.type) === true) return false
     // Make sure there is only one error per fieldName
     if (addedFieldNames.has(errObj.name)) return false
+    // Make sure we only add errors for keys that the user requested
+    if (Array.isArray(keysToValidate) && !keysToValidate.includes(errObj.name)) return false
 
     addedFieldNames.add(errObj.name)
     return true

--- a/src/doValidation.ts
+++ b/src/doValidation.ts
@@ -119,7 +119,7 @@ function doValidation ({
     // Make sure there is only one error per fieldName
     if (addedFieldNames.has(errObj.name)) return false
     // Make sure we only add errors for keys that the user requested
-    if (Array.isArray(keysToValidate) && !keysToValidate.includes(errObj.name)) return false
+    if (Array.isArray(keysToValidate) && keysToValidate?.some((key) => errObj.name.startsWith(key))) return false
 
     addedFieldNames.add(errObj.name)
     return true

--- a/src/doValidation.ts
+++ b/src/doValidation.ts
@@ -111,6 +111,14 @@ function doValidation ({
   if (wholeDocumentErrors.length > 0) {
     validationErrors.push(...wholeDocumentErrors)
   }
+  
+  function isIgnoredKey (key: string): boolean {
+    if (!Array.isArray(keysToValidate)) return false
+    for (const keyToValidate of keysToValidate) {
+      if (keyToValidate === key || key.startsWith(`${key}.`)) return false
+    }
+    return true
+  }
 
   const addedFieldNames = new Set<string>()
   return validationErrors.filter((errObj) => {
@@ -119,7 +127,7 @@ function doValidation ({
     // Make sure there is only one error per fieldName
     if (addedFieldNames.has(errObj.name)) return false
     // Make sure we only add errors for keys that the user requested
-    if (Array.isArray(keysToValidate) && keysToValidate?.some((key) => errObj.name.startsWith(key))) return false
+    if (isIgnoredKey(errObj.name)) return false
 
     addedFieldNames.add(errObj.name)
     return true


### PR DESCRIPTION
Ran into an issue after upgrading to v3 where they `keys` validation option would not be respected anymore.

This pull request adds a check to the final `doValidation()` filter, where any errors not matching the provided `keysToValidate` argument are discarded. 

Reference #477