### PR TITLE
Removed supported constructor option warning on already supported option

### DIFF
--- a/src/SimpleSchema.ts
+++ b/src/SimpleSchema.ts
@@ -80,7 +80,8 @@ class SimpleSchema {
     'getErrorMessage',
     'humanizeAutoLabels',
     'keepRawDefinition',
-    'requiredByDefault'
+    'requiredByDefault',
+    'defaultLabel'
   ])
 
   /**


### PR DESCRIPTION
the option `defaultLabel` is already a supported option for the `SimpleSchema.constructorOptionDefaults` function. This code change removes the warning associated with using the `defaultLabel` option in said function

one example location where `defaultLabel` is supported as a default option: https://github.com/longshotlabs/simpl-schema/blob/7c47b55494646cd2d816ea00e8c79e173e8d2456/src/SimpleSchema.ts#L1318